### PR TITLE
Avoid counting multiple misses with MSHR full

### DIFF
--- a/src/cache.cc
+++ b/src/cache.cc
@@ -169,9 +169,7 @@ bool CACHE::try_hit(const tag_lookup_type& handle_pkt)
       ++sim_stats.pf_useful;
       way->prefetch = false;
     }
-  } else {
-    ++sim_stats.misses[champsim::to_underlying(handle_pkt.type)][handle_pkt.cpu];
-  }
+  } 
 
   return hit;
 }
@@ -252,6 +250,8 @@ bool CACHE::handle_miss(const tag_lookup_type& handle_pkt)
     }
   }
 
+  ++sim_stats.misses[champsim::to_underlying(handle_pkt.type)][handle_pkt.cpu];
+
   return true;
 }
 
@@ -265,6 +265,8 @@ bool CACHE::handle_write(const tag_lookup_type& handle_pkt)
 
   inflight_writes.emplace_back(handle_pkt, current_cycle);
   inflight_writes.back().event_cycle = current_cycle + (warmup ? 0 : FILL_LATENCY);
+    
+  ++sim_stats.misses[champsim::to_underlying(handle_pkt.type)][handle_pkt.cpu];
 
   return true;
 }


### PR DESCRIPTION
Fixed cache miss count in case of an MSHR full. The miss should only be counted once rather than in every cycle until an MSHR becomes available.